### PR TITLE
[Feat] 일기 보관 여부 / 날짜별 상세 조회 API 연결

### DIFF
--- a/app/src/main/java/com/example/a_write/DiaryDetailFragment.kt
+++ b/app/src/main/java/com/example/a_write/DiaryDetailFragment.kt
@@ -13,6 +13,7 @@ import android.view.Window
 import android.widget.ImageView
 import androidx.fragment.app.Fragment
 import com.example.a_write.api.DiaryResult
+import com.example.a_write.api.DiaryService
 import com.example.a_write.databinding.FragmentDiaryDetailBinding
 import com.squareup.picasso.Picasso
 
@@ -37,6 +38,8 @@ class DiaryDetailFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View {
         binding = FragmentDiaryDetailBinding.inflate(inflater, container, false)
+
+        val diaryService = DiaryService(requireActivity())
 
         val diary: DiaryResult? = arguments?.getParcelable(ARG_DIARY)
 
@@ -68,14 +71,14 @@ class DiaryDetailFragment : Fragment() {
 
         heartOffImageView.setOnClickListener {
             diary?.let {
-                it.heartby = true
+                diaryService.postDiaryHeart(it.diaryId)
                 updateHeartVisibility(true)
             }
         }
 
         heartOnImageView.setOnClickListener {
             diary?.let {
-                it.heartby = false
+                diaryService.deleteDiaryHeart(it.diaryId)
                 updateHeartVisibility(false)
             }
         }

--- a/app/src/main/java/com/example/a_write/HeartFragment.kt
+++ b/app/src/main/java/com/example/a_write/HeartFragment.kt
@@ -14,6 +14,7 @@ import com.example.a_write.databinding.FragmentHeartBinding
 class HeartFragment(private val diaryService: DiaryService) : Fragment(), HeartDataListener {
 
     private lateinit var binding: FragmentHeartBinding
+    private lateinit var heartPreviewDiaryRVAdapter: HeartPreviewDiaryRVAdapter
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -21,20 +22,25 @@ class HeartFragment(private val diaryService: DiaryService) : Fragment(), HeartD
     ): View {
         binding = FragmentHeartBinding.inflate(inflater, container, false)
 
+        //  보관함 RV
+        heartPreviewDiaryRVAdapter = HeartPreviewDiaryRVAdapter(
+            emptyList(),
+            diaryService,
+            { diary -> navigateToAnotherPage(diary) },
+            { diaryService.getHeartList(this) }
+        )
+
+        binding.heartDiaryPostsRv.adapter = heartPreviewDiaryRVAdapter
+        binding.heartDiaryPostsRv.layoutManager =
+            LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
+
         diaryService.getHeartList(this)
 
         return binding.root
     }
 
     override fun onDataLoaded(diaries: List<DiaryResult>) {
-        //  보관함 RV
-        val heartPreviewDiaryRVAdapter =
-            HeartPreviewDiaryRVAdapter(diaries, diaryService) { diary: DiaryResult ->
-                navigateToAnotherPage(diary)
-            }
-        binding.heartDiaryPostsRv.adapter = heartPreviewDiaryRVAdapter
-        binding.heartDiaryPostsRv.layoutManager =
-            LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
+        heartPreviewDiaryRVAdapter.updateData(diaries)
     }
 
     private fun navigateToAnotherPage(diary: DiaryResult) {

--- a/app/src/main/java/com/example/a_write/HeartPreviewDiaryRVAdapter.kt
+++ b/app/src/main/java/com/example/a_write/HeartPreviewDiaryRVAdapter.kt
@@ -7,13 +7,20 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.a_write.api.DiaryResult
 import com.example.a_write.api.DiaryService
 import com.example.a_write.databinding.ItemPreviewDiaryBinding
+import kotlinx.coroutines.*
 
 class HeartPreviewDiaryRVAdapter(
-    private val diaries: List<DiaryResult>,
+    private var diaries: List<DiaryResult>,
     private val diaryService: DiaryService,
-    private val onItemClicked: (DiaryResult) -> Unit
+    private val onItemClicked: (DiaryResult) -> Unit,
+    private val onLikeClicked: () -> Unit
 ) :
     RecyclerView.Adapter<HeartPreviewDiaryRVAdapter.ViewHolder>() {
+    fun updateData(newDiaries: List<DiaryResult>) {
+        diaries = newDiaries
+        notifyDataSetChanged()
+    }
+
     override fun onCreateViewHolder(
         viewGroup: ViewGroup,
         viewType: Int
@@ -32,7 +39,7 @@ class HeartPreviewDiaryRVAdapter(
         holder.bind(diaries[position], this, onItemClicked)
     }
 
-    class ViewHolder(
+    inner class ViewHolder(
         private val binding: ItemPreviewDiaryBinding,
         private val diaryService: DiaryService
     ) :
@@ -49,7 +56,12 @@ class HeartPreviewDiaryRVAdapter(
             binding.itemDiaryHeartOffIv.visibility = if (diary.heartby) View.GONE else View.VISIBLE
 
             binding.itemDiaryHeartOnIv.setOnClickListener {
-                diaryService.deleteDiaryHeart(diary.diaryId)
+                CoroutineScope(Dispatchers.Main).launch {
+                    withContext(Dispatchers.IO) {
+                        diaryService.deleteDiaryHeart(diary.diaryId)
+                    }
+                    onLikeClicked()
+                }
             }
 
             binding.root.setOnClickListener {

--- a/app/src/main/java/com/example/a_write/ProfileDiaryActivity.kt
+++ b/app/src/main/java/com/example/a_write/ProfileDiaryActivity.kt
@@ -29,17 +29,17 @@ class ProfileDiaryActivity : AppCompatActivity(), MyPageCalenderDiaryListener {
 
         myPageService = MyPageService(applicationContext)
 
-        // 선택한 날짜 확인
+        // 선택한 날짜 가져오기
         val selectedDate = intent.getStringExtra("selectedDate")
         val selectedYear = intent.getIntExtra("selectedYear", 0)
-        val selectedMonth = intent.getIntExtra("selectedMonth", 0)
-
-        Log.d("선택한 날짜 확인", "Selected Date: $selectedYear $selectedMonth $selectedDate")
+        val selectedMonth = intent.getStringExtra("selectedMonth")
 
         if (selectedYear != 0) {
+            // 캘린더를 클릭한 경우
             val formattedDate = "$selectedYear-$selectedMonth-$selectedDate"
             myPageService.getCalenderDiaryDetail(this, formattedDate)
         } else {
+            // 인기 일기 RVA를 클릭한 경우
             val titleTextView: TextView = findViewById(R.id.profile_diary_title_tv)
             val contentTextView: TextView = findViewById(R.id.profile_diary_content_tv)
             val diaryImageView: ImageView = findViewById(R.id.profile_diary_img_iv)
@@ -95,8 +95,10 @@ class ProfileDiaryActivity : AppCompatActivity(), MyPageCalenderDiaryListener {
     override fun onDataLoaded(diary: MyPageDiary) {
         val titleTextView: TextView = findViewById(R.id.profile_diary_title_tv)
         val contentTextView: TextView = findViewById(R.id.profile_diary_content_tv)
+        val diaryImageView: ImageView = findViewById(R.id.profile_diary_img_iv)
         titleTextView.text = diary.title
         contentTextView.text = diary.content
+        Picasso.get().load(diary.imgUrl).into(diaryImageView)
         diaryId = diary.diaryId
     }
 

--- a/app/src/main/java/com/example/a_write/ProfileFragment.kt
+++ b/app/src/main/java/com/example/a_write/ProfileFragment.kt
@@ -46,6 +46,7 @@ class ProfileFragment(private val myPageService: MyPageService) : Fragment(), My
         val calendar = Calendar.getInstance()
         val year = calendar.get(Calendar.YEAR)
         val month = calendar.get(Calendar.MONTH)
+        val formattedMonth = String.format("%02d", month + 1)
 
         val calendarGridView: GridView = binding.calendarGv
 
@@ -58,15 +59,18 @@ class ProfileFragment(private val myPageService: MyPageService) : Fragment(), My
                     val intent = Intent(requireContext(), ProfileDiaryActivity::class.java)
                     intent.putExtra("selectedDate", date)
                     intent.putExtra("selectedYear", year)
-                    intent.putExtra("selectedMonth", month + 1)
-                    val formattedDate = "$year-${month + 1}-$date"
+                    intent.putExtra("selectedMonth", formattedMonth)
+                    val formattedDate = "$year-${formattedMonth}-$date"
+                    Log.d("API date", formattedDate)
 
-                    val isSuccess = myPageService.getCalenderBool(formattedDate)
-                    if (isSuccess) {
-                        startActivity(intent)
-                    } else {
-                        showToast(requireContext(),"날짜에 해당하는 일기가 없습니다.")
+                    myPageService.getCalenderBool(formattedDate) { isSuccess ->
+                        if (isSuccess) {
+                            startActivity(intent)
+                        } else {
+                            showToast(requireContext(), "날짜에 해당하는 일기가 없습니다.")
+                        }
                     }
+
                 }
             })
 

--- a/app/src/main/java/com/example/a_write/ProfileSettingActivity.kt
+++ b/app/src/main/java/com/example/a_write/ProfileSettingActivity.kt
@@ -87,7 +87,8 @@ class ProfileSettingActivity : AppCompatActivity(), ProfileChooseIconDialog.OnIc
 
     override fun onUserDataLoaded(data: UserInfo) {
         originalProfileId = data.profileImg
-        Log.d("API oP", originalProfileId.toString())
+        selectedProfileId = data.profileImg
+        Log.d("API originalProfileId", originalProfileId.toString())
 
         // 프로필 이미지 띄우기
         profileImageView.setImageResource(getProfileImageResourceId(originalProfileId))

--- a/app/src/main/java/com/example/a_write/api/DiaryService.kt
+++ b/app/src/main/java/com/example/a_write/api/DiaryService.kt
@@ -73,7 +73,7 @@ class DiaryService(private val context: Context) {
     fun deleteDiaryHeart(diaryId: Int) {
         diaryService.deleteHeart(diaryId).enqueue(object : Callback<Void> {
             override fun onResponse(call: Call<Void>, response: Response<Void>) {
-                Log.d("API postDiaryHeart", response.toString())
+                Log.d("API deleteDiaryHeart", response.toString())
             }
 
             override fun onFailure(call: Call<Void>, t: Throwable) {

--- a/app/src/main/java/com/example/a_write/api/MyPageService.kt
+++ b/app/src/main/java/com/example/a_write/api/MyPageService.kt
@@ -67,22 +67,19 @@ class MyPageService(private val context: Context) {
         })
     }
 
-    fun getCalenderBool(date: String): Boolean {
-        var isSuccess = false
+    fun getCalenderBool(date: String, callback: (Boolean) -> Unit) {
         myPageService.getCalenderDiary(date).enqueue(object : Callback<MyPageDiary> {
             override fun onResponse(call: Call<MyPageDiary>, response: Response<MyPageDiary>) {
-                if (response.isSuccessful) {
-                    isSuccess = true
-                }
-                Log.d("API getCalenderDiaryDetail", response.toString())
+                val isSuccess = response.code() == 200
+                Log.d("API getCalenderBool", response.toString())
+                callback(isSuccess)
             }
 
             override fun onFailure(call: Call<MyPageDiary>, t: Throwable) {
-                isSuccess = false
-                Log.d("API getCalenderDiaryDetail ERROR", "$t")
+                Log.d("API getCalenderBool ERROR", "$t")
+                callback(false)
             }
         })
-        return isSuccess
     }
 
     fun getUserInfo(listener: MyPageUserInfoListener) {


### PR DESCRIPTION
- 보관함에서 일기 삭제 시 데이터 실시간 반영
- 일기 상세 화면에서 일기 보관 여부 핸들링
- 프로필 변경 시 이미지 선택을 하지 않은 상태에서 적용 버튼을 클릭하면 1번 이미지로 설정됐던 오류 해결
- 날짜별 상세 조회 API 연결

- 일기 보관 여부 API / 보관함 목록 API 테스트 완료
- 일기 삭제 API 테스트 완료